### PR TITLE
波形表示および音声再生を追加、Processの高速化など

### DIFF
--- a/src/SamplerLegacy.cpp
+++ b/src/SamplerLegacy.cpp
@@ -81,7 +81,8 @@ void SamplerLegacy::SetSample(uint8_t channel, Sample *s)
     sample = s;
 }
 
-void SamplerLegacy::Process(int16_t *output)
+__attribute((optimize("-O3")))
+void SamplerLegacy::Process(int16_t* __restrict__ output)
 {
     float data[SAMPLE_BUFFER_SIZE] = {0.0f};
 
@@ -99,57 +100,135 @@ void SamplerLegacy::Process(int16_t *output)
 
         float pitch = PitchFromNoteNo(player->noteNo, player->sample->root);
 
-        if (sample->adsrEnabled) // adsrEnabledによる場合分けが多いので、まずadsrEnabledで分ける
-        {
-            for (int n = 0; n < SAMPLE_BUFFER_SIZE; n++)
-            {
-                // 波形を読み込む&線形補完
-                float val = (sample->sample[player->pos + 1] * player->pos_f) + (sample->sample[player->pos] * (1.0f - player->pos_f));
-                val *= player->adsrGain;
-                data[n] += val;
+        int32_t loopEnd = sample->length;
+        int32_t loopBack = 0;
+        float gain = player->volume;
+        // adsrEnabledが有効の場合はループポイントとadsrGainを使用する。
+        if (sample->adsrEnabled) {
+            loopEnd = sample->loopEnd;
+            loopBack = sample->loopStart - loopEnd;
+            gain = player->adsrGain;
+        }
 
-                // 次のサンプルへ移動
-                int32_t pitch_u = pitch;
-                player->pos_f += pitch - pitch_u;
-                player->pos += pitch_u;
-                if (player->pos_f >= 1.0f)
-                {
-                    player->pos++;
-                    player->pos_f--;
+        // gainにマスターボリュームを適用しておく
+        gain *= masterVolume;
+
+        // playerのメンバであるposとpos_fをローカル変数にコピーしておく。
+        auto pos = player->pos;
+        float pos_f = player->pos_f;
+        auto src = sample->sample;
+
+        if (pitch < 1.0f)
+        { // pitchが1未満の場合は線形補間処理を行う。
+            uint32_t n = 0;
+            int32_t current_sample = src[pos];
+            int32_t next_sample = src[pos + 1];
+            float diff = next_sample - current_sample;
+            do
+            {
+                // 現在の値をpos_fに応じて線形補間
+                float val = (float)current_sample + diff * pos_f;
+                // gainを掛けて波形合成
+                data[n] += val * gain;
+                pos_f += pitch;
+                if (pos_f >= 1.0f) {
+                    // pitchが1未満の条件下にあるため、pos_f+pitchは2未満であることが保証される。
+                    pos_f-=1.0f;
+                    if (++pos >= loopEnd) {
+                        pos += loopBack;
+                        if (loopBack == 0)
+                        {   // ループポイントが設定されていない場合は再生を停止する
+                            player->playing = false;
+                            break;
+                        }
+                    }
+                    current_sample = next_sample;
+                    next_sample = src[pos + 1];
+                    diff = next_sample - current_sample;
+                }
+            } while (++n < SAMPLE_BUFFER_SIZE);
+        } else {
+            // pitchが1以上の場合は補間処理の効果がそれほど高くないと思われるので処理を省いて高速化する
+            // ループの残り回数をremainに保持しておく
+            uint32_t remain = SAMPLE_BUFFER_SIZE;
+            auto d = data;
+            do {
+                // loopEndに到達するまで何個サンプル出力できるか求める
+                int32_t length = 1 + ((loopEnd - pos) / pitch);
+                // ループの残り回数を考慮してlengthを調整
+                length = remain < length ? remain : length;
+                // ループ残り回数をカウントダウン
+                remain -= length;
+                if (length & 3)
+                { // 後で4個単位でサンプル処理するので、先に端数分のループを処理する
+                    int l = length & 3;
+                    do {
+                        // 補間処理を省略して波形合成
+                        d[0] += src[pos] * gain;
+                        d += 1;
+                        pos_f += pitch;
+                        uint32_t intval = pos_f;
+                        pos += intval;
+                        pos_f -= intval;
+                    } while (--l);
+                }
+                // lengthを右2ビットシフトしてループ回数を 1/4にしておく
+                length >>= 2;
+                if (length)
+                { // 4個単位でサンプル処理を行う
+                    do {
+                        auto s = &src[pos];
+                        float pf1 = pos_f + pitch;
+                        float pf2 = pf1 + pitch;
+                        float pf3 = pf2 + pitch;
+                        float d0 = d[0] + s[0            ] * gain;
+                        float d1 = d[1] + s[(uint32_t)pf1] * gain;
+                        float d2 = d[2] + s[(uint32_t)pf2] * gain;
+                        float d3 = d[3] + s[(uint32_t)pf3] * gain;
+                        pos_f = pf3 + pitch;
+                        uint32_t intval = (uint32_t)pos_f;
+                        pos += intval;
+                        pos_f -= intval;
+                        d[0] = d0;
+                        d[1] = d1;
+                        d[2] = d2;
+                        d[3] = d3;
+                        d += 4;
+                    } while (--length);
                 }
 
-                // ループポイントが設定されている場合はループする
-                while (player->pos >= sample->loopEnd)
-                    player->pos -= (sample->loopEnd - sample->loopStart);
-            }
-        }
-        else
-        {
-            for (int n = 0; n < SAMPLE_BUFFER_SIZE; n++)
-            {
-                if (player->pos >= sample->length)
-                {
-                    player->playing = false;
-                    break;
+                if (pos >= loopEnd) {
+                    if (loopBack == 0)
+                    {   // ループポイントが設定されていない場合は再生を停止する
+                        player->playing = false;
+                        break;
+                    }
+                    while (pos >= loopEnd) {
+                        pos += loopBack;
+                    }
                 }
-                // 波形を読み込む
-                float val = sample->sample[player->pos];
-                val *= player->volume;
-                data[n] += val;
-
-                // 次のサンプルへ移動
-                int32_t pitch_u = pitch;
-                player->pos_f += pitch - pitch_u;
-                player->pos += pitch_u;
-                int posI = player->pos_f;
-                player->pos += posI;
-                player->pos_f -= posI;
-            }
+            } while (remain != 0);
         }
+        // ループを終えた後でposとpos_fをplayerに書き戻しておく
+        player->pos = pos;
+        player->pos_f = pos_f;
     }
 
-    for (uint8_t i = 0; i < SAMPLE_BUFFER_SIZE; i++)
     {
-        output[i] = int16_t(data[i] * masterVolume);
+        auto o = output;
+        auto d = data;
+        for (int i = 0; i < SAMPLE_BUFFER_SIZE>>3; i++)
+        { // 事前にマスターボリュームを適用しているので単純に代入するのみでよい
+            o[0] = d[0];
+            o[1] = d[1];
+            o[2] = d[2];
+            o[3] = d[3];
+            o[4] = d[4];
+            o[5] = d[5];
+            o[6] = d[6];
+            o[7] = d[7];
+            o += 8;
+            d += 8;
+        }
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include <SamplerLegacy.h>
 #include <piano.h>
 
-#define ENABLE_PRINTING true
+#define ENABLE_PRINTING false
 
 static struct Sample piano = Sample{
     piano_sample,
@@ -19,27 +19,64 @@ static struct Sample piano = Sample{
 
 SamplerLegacy samplerLegacy;
 
-inline void process(SamplerBase *sampler, int16_t *output)
+static constexpr const uint8_t SPK_CH = 1;
+
+uint32_t process(SamplerBase *sampler, int16_t *output)
 {
+  uint32_t cycle_begin, cycle_end;
+  __asm__ __volatile("rsr %0, ccount" : "=r"(cycle_begin) ); // 処理前のCPUサイクル値を取得
   sampler->Process(output);
+  __asm__ __volatile("rsr %0, ccount" : "=r"(cycle_end) ); // 処理後のCPUサイクル値を取得
+  uint32_t cycle = cycle_end - cycle_begin;
 #if ENABLE_PRINTING
   for (uint8_t i; i < SAMPLE_BUFFER_SIZE; i++)
   {
     Serial.printf("%d,", output[i]);
   }
+#else
+  M5.Speaker.playRaw(output, SAMPLE_BUFFER_SIZE, SAMPLE_RATE, false, 1, SPK_CH);
+  static int16_t prev_yh[320][2];
+  {
+    static int max_y = 0;
+    static int min_y = 1024;
+    static int x = 0;
+    static int y1 = 0;
+    int dh = M5.Display.height();
+    for (int i = 0; i < SAMPLE_BUFFER_SIZE; i++)
+    {
+      M5.Display.writeFastVLine(x, prev_yh[x][0], prev_yh[x][1], TFT_BLACK);
+      int y0 = (dh >> 1) - (output[i] >> 7);
+      if (min_y > y0) { min_y = y0; }
+      if (max_y < y0) { max_y = y0; }
+      int y = y0 < y1 ? y0 : y1;
+      int h = y0 < y1 ? y1 : y0;
+      y1 = y0;
+      h = h - y + 1;
+      M5.Display.writeFastVLine(x, y, h, TFT_WHITE);
+      prev_yh[x][0] = y;
+      prev_yh[x][1] = h;
+      ++x;
+      if (x >= M5.Display.width()) { x = 0; }
+    }
+  }
 #endif
+  // 波形合成処理に掛かったCPUサイクル数を返す
+  return cycle;
 }
 
-time_t benchmark(SamplerBase *sampler)
+uint32_t benchmark(SamplerBase *sampler)
 {
+  int16_t output[2][SAMPLE_BUFFER_SIZE] = {0};
+  bool buf_idx = false;
   samplerLegacy = SamplerLegacy();
 
-  unsigned long startTime = micros();
+  uint32_t cycle_count = 0;
 
   sampler->SetSample(0, &piano);
-  int16_t output[SAMPLE_BUFFER_SIZE] = {0};
   uint32_t processedSamples = 0; // 処理済みのサンプル数
 
+  M5.Speaker.playRaw(output[buf_idx], SAMPLE_BUFFER_SIZE, SAMPLE_RATE, false, 1, SPK_CH);
+  buf_idx = !buf_idx;
   // 0秒時点の処理
   sampler->NoteOn(60, 127, 0); // ド
   sampler->NoteOn(64, 127, 0); // ミ
@@ -47,7 +84,8 @@ time_t benchmark(SamplerBase *sampler)
   uint32_t nextGoal = SAMPLE_RATE * 1;
   while (processedSamples < nextGoal)
   {
-    process(sampler, output);
+    cycle_count += process(sampler, output[buf_idx]);
+    buf_idx = !buf_idx;
     processedSamples += SAMPLE_BUFFER_SIZE;
   }
 
@@ -58,20 +96,36 @@ time_t benchmark(SamplerBase *sampler)
   nextGoal = SAMPLE_RATE * 2;
   while (processedSamples < nextGoal)
   {
-    process(sampler, output);
+    cycle_count += process(sampler, output[buf_idx]);
+    buf_idx = !buf_idx;
     processedSamples += SAMPLE_BUFFER_SIZE;
   }
 
   // 2秒で終了
 
-  unsigned long endTime = micros();
-  return endTime - startTime;
+  while (M5.Speaker.isPlaying()) {
+    M5.delay(1);
+  }
+
+  // CPUサイクル数をマイクロ秒に変換して返す
+  return cycle_count / getCpuFrequencyMhz();
 }
 
 void setup()
 {
   M5.begin();
-  M5.Display.setRotation(M5.Display.getRotation() ^ 1);
+  {
+    auto spk_cfg = M5.Speaker.config();
+    spk_cfg.sample_rate = 48000;
+    spk_cfg.task_pinned_core = PRO_CPU_NUM;
+    spk_cfg.dma_buf_len = 64;
+    spk_cfg.dma_buf_count = 16;
+
+    M5.Speaker.config(spk_cfg);
+    M5.Speaker.setVolume(192);
+  }
+  M5.Display.startWrite();
+  // M5.Display.setRotation(M5.Display.getRotation() ^ 1);
   M5.Display.setTextSize(2);
   M5.Display.println("Hello World!");
   M5.Display.println("");
@@ -83,12 +137,15 @@ void loop()
   auto touch = M5.Touch.getDetail();
   if (touch.wasClicked() && touch.base_y < M5.Display.height())
   {
+    M5.Display.clear();
+    M5.Display.setCursor(0,0);
     M5.Display.println("Processing...");
     time_t elapsedTime = benchmark(&samplerLegacy);
 #if ENABLE_PRINTING
     M5.Display.println("Processed.");
 #else
     M5.Display.printf("Elapsed time: %ld us\n", elapsedTime);
+    M5.Log.printf("Elapsed time: %ld us\n", elapsedTime);
 #endif
   }
   delay(100);


### PR DESCRIPTION
素敵なプロジェクトの公開ありがとうございます！

早速ではありますが、以下よろしくお願いいたします。

- #define ENABLE_PRINTING false が指定されている場合、
 画面に波形表示しつつ M5.Speakerから生成した音を再生できるようにしてみました。

- ベンチの計測時間をより厳密に測定するようにしました。

- Processの処理をなるべく高速になるよう色々調整しました。

なお『pitchが1以上の時は線形補間を省略する』という仕様に変更をいたしました。
pitch が 1未満の場合は引き延ばして再生されるため線形補間がとても有効ですが、
1以上の場合は引き延ばしではなく圧縮方向となるため、補間処理よりも速度向上に振った感じです。
この仕様がもしかするとwararyoさんの意図にそぐわない可能性があるので、ご検討お願いいたします。