### PR TITLE
アセンブリ言語使用による高速化

### DIFF
--- a/src/SamplerBase.h
+++ b/src/SamplerBase.h
@@ -2,7 +2,13 @@
 
 #include <stdio.h>
 
-#define SAMPLE_BUFFER_SIZE 64
+// ADSR更新周期 (サンプル数)
+// ※ ADSRの更新周期が短いほど、ADSRの変化が滑らかになりますが、CPU負荷が増加します
+#define ADSR_UPDATE_SAMPLE_COUNT 64
+
+// 1回の波形生成処理で出力するサンプル数 (ADSR_UPDATE_SAMPLE_COUNT の倍数であること)
+// ※ この数値が大きいほど、波形生成処理の効率が向上しますが、操作してから発音されるまでのレイテンシが増加します
+#define SAMPLE_BUFFER_SIZE ( ADSR_UPDATE_SAMPLE_COUNT * 2 )
 #define SAMPLE_RATE 48000
 
 #define MAX_SOUND 16 // 最大同時発音数

--- a/src/SamplerOptimized.S
+++ b/src/SamplerOptimized.S
@@ -1,0 +1,55 @@
+#if defined ( __XTENSA__ )
+
+#if __has_include (<sdkconfig.h>)
+#include <sdkconfig.h>
+#endif
+
+// void sampler_process_inner(proc_inner_work_t* result, uint32_t length, float gain, float pitch)
+// a2 = sampler_process_inner の引数
+// a3 = uint32_t length
+// a4 = float gain
+// a5 = float pitch
+    .global     sampler_process_inner
+    .section    .text
+    .align      4
+sampler_process_inner:
+    entry       sp, 32
+    beqz        a3, FUNC1_END
+    wfr         f4, a4                  // f4 に gain を設定
+    wfr         f5, a5                  // f5 に pitch を設定
+    l32i        a9, a2, 4               // a13 に出力先アドレスを取得
+    l32i        a8, a2, 0               // a8 に元データのアドレスを取得
+    lsi         f0, a2, 8               // f0 に pos_f を設定
+    addx4       a13, a3, a9             // a15 に出力先アドレスの終了アドレスを設定
+    s32i        a13, a2, 4              // 出力先終了アドレスを結果データに先に書き戻して置く
+    addi        a9, a9, -4              // 出力先アドレスを 4 バイト戻す(ループ内の最適化の都合)
+    add.s       f3, f0, f5              // f3 = posf + pitch 新しい pos_f を計算
+    l16si       a15, a8, 0              // a15 に元データ[0]を取得
+    l16si       a14, a8, 2              // a14 に元データ[1]を取得
+    // ループ開始前に初回データの準備としてf3,a14,a15を準備しておく
+
+    loop        a3, FUNC1_LOOP_END      // ループ開始
+                              //↓ここのコメントは結果が出るまでに必要なCPUサイクル数。
+                              // 例えば a12:3c は a12に結果が出るのに3サイクルかかることを示す
+    utrunc.s    a12, f3, 0    //a12:3c  // a12 = f3 新しい pos_f の整数部分を取得
+    sub         a14, a14, a15           // a14 = diff = s[1] - s[0] // 元データの差分を計算
+    float.s     f15, a15, 0   //f15:1c  // f15 = (float)a15 元データ[0]をfloat値に変換
+    float.s     f14, a14, 0   //f14:1c  // f14 = diff = (float)a14 差分値を float に変換
+    lsi         f13, a9, 4              // f13 に既存の合成波形を読出しておく (事前に-4しているので+4オフセット)
+    ufloat.s    f12, a12, 0   //f12:1c  // f12 = pos_fの整数部分をfloatに変換
+    madd.s      f15, f14, f0  //f15:3c  // 出力値 f15 += diff * pitch
+    sub.s       f0, f3, f12   // f0:3c  // f0 = 新しいpos_fの小数部分を計算
+    addi        a9, a9, 4               // 合成波形の出力先を 4 バイト進める
+    addx2       a8, a12, a8             // 元データのアドレスを pos_f の整数部分の分進める
+    madd.s      f13, f15, f4  //f13:3c  // f13 += 出力値 * gain
+    add.s       f3, f0, f5    // f3:3c  // 次回のループで使う新しい pos_f を計算 (f3 = pos_f + pitch)
+    l16si       a15, a8, 0              // 次回のループで使う元データ s[0] を取得
+    l16si       a14, a8, 2              // 次回のループで使う元データ s[1] を取得
+    ssi         f13, a9, 0              // 合成結果の値f13を出力先にストア
+FUNC1_LOOP_END:
+    s32i        a8, a2, 0
+    ssi         f0, a2, 8
+FUNC1_END:
+    retw
+
+#endif

--- a/src/SamplerOptimized.S
+++ b/src/SamplerOptimized.S
@@ -4,52 +4,50 @@
 #include <sdkconfig.h>
 #endif
 
-// void sampler_process_inner(proc_inner_work_t* result, uint32_t length, float gain, float pitch)
-// a2 = sampler_process_inner の引数
+// void sampler_process_inner(proc_inner_work_t* work, uint32_t length)
+// a2 = proc_inner_work_t* work
 // a3 = uint32_t length
-// a4 = float gain
-// a5 = float pitch
     .global     sampler_process_inner
     .section    .text
     .align      4
 sampler_process_inner:
     entry       sp, 32
-    beqz        a3, FUNC1_END
-    wfr         f4, a4                  // f4 に gain を設定
-    wfr         f5, a5                  // f5 に pitch を設定
-    l32i        a9, a2, 4               // a13 に出力先アドレスを取得
-    l32i        a8, a2, 0               // a8 に元データのアドレスを取得
-    lsi         f0, a2, 8               // f0 に pos_f を設定
-    addx4       a13, a3, a9             // a15 に出力先アドレスの終了アドレスを設定
-    s32i        a13, a2, 4              // 出力先終了アドレスを結果データに先に書き戻して置く
-    addi        a9, a9, -4              // 出力先アドレスを 4 バイト戻す(ループ内の最適化の都合)
-    add.s       f3, f0, f5              // f3 = posf + pitch 新しい pos_f を計算
-    l16si       a15, a8, 0              // a15 に元データ[0]を取得
-    l16si       a14, a8, 2              // a14 に元データ[1]を取得
-    // ループ開始前に初回データの準備としてf3,a14,a15を準備しておく
+    beqz        a3, PROC_INNER1_END
+    l32i        a11,a2, 0               // a11 に元データのアドレスを取得
+    l32i        a13,a2, 4               // a13 に出力先アドレスを取得
+    lsi         f8, a2, 8               // f8 に pos_f を設定
+    lsi         f9, a2, 12              // f9 に gain を設定
+    lsi         f10,a2, 16              // f10 に pitch を設定
+    addx4       a15,a3, a13             // a15 に出力先アドレスの終了アドレスを設定
+    s32i        a15,a2, 4               // 出力先終了アドレスを結果データに先に書き戻して置く
+    addi        a13,a13,-4              // 出力先アドレスを 4 バイト戻す(ループ内の最適化の都合)
+    add.s       f11,f8, f10             // f11 = posf + pitch 新しい pos_f を計算
+    l16si       a15,a11,0               // a15 に元データ[0]を取得
+    l16si       a14,a11,2               // a14 に元データ[1]を取得
+    // ループ開始前に初回データの準備としてf11,a14,a15を準備しておく
 
-    loop        a3, FUNC1_LOOP_END      // ループ開始
-                              //↓ここのコメントは結果が出るまでに必要なCPUサイクル数。
-                              // 例えば a12:3c は a12に結果が出るのに3サイクルかかることを示す
-    utrunc.s    a12, f3, 0    //a12:3c  // a12 = f3 新しい pos_f の整数部分を取得
-    sub         a14, a14, a15           // a14 = diff = s[1] - s[0] // 元データの差分を計算
-    float.s     f15, a15, 0   //f15:1c  // f15 = (float)a15 元データ[0]をfloat値に変換
-    float.s     f14, a14, 0   //f14:1c  // f14 = diff = (float)a14 差分値を float に変換
-    lsi         f13, a9, 4              // f13 に既存の合成波形を読出しておく (事前に-4しているので+4オフセット)
-    ufloat.s    f12, a12, 0   //f12:1c  // f12 = pos_fの整数部分をfloatに変換
-    madd.s      f15, f14, f0  //f15:3c  // 出力値 f15 += diff * pitch
-    sub.s       f0, f3, f12   // f0:3c  // f0 = 新しいpos_fの小数部分を計算
-    addi        a9, a9, 4               // 合成波形の出力先を 4 バイト進める
-    addx2       a8, a12, a8             // 元データのアドレスを pos_f の整数部分の分進める
-    madd.s      f13, f15, f4  //f13:3c  // f13 += 出力値 * gain
-    add.s       f3, f0, f5    // f3:3c  // 次回のループで使う新しい pos_f を計算 (f3 = pos_f + pitch)
-    l16si       a15, a8, 0              // 次回のループで使う元データ s[0] を取得
-    l16si       a14, a8, 2              // 次回のループで使う元データ s[1] を取得
-    ssi         f13, a9, 0              // 合成結果の値f13を出力先にストア
-FUNC1_LOOP_END:
-    s32i        a8, a2, 0
-    ssi         f0, a2, 8
-FUNC1_END:
+    loop        a3, PROC_INNER1_LOOP_END      // ループ開始
+                            //↓ここのコメントは結果が出るまでに必要なCPUサイクル数。
+                            // 例えば a12:3c は a12に結果が出るのに3サイクルかかることを示す
+    utrunc.s    a12,f11,0   //a12:3c    // a12 = f11 新しい pos_f の整数部分を取得
+    sub         a14,a14,a15             // a14 = diff = s[1] - s[0] // 元データの差分を計算
+    float.s     f15,a15,0   //f15:1c    // f15 = (float)a15 元データ[0]をfloat値に変換
+    float.s     f14,a14,0   //f14:1c    // f14 = diff = (float)a14 差分値を float に変換
+    lsi         f13,a13,4               // f13 に既存の合成波形を読出しておく (事前に-4しているので+4オフセット)
+    ufloat.s    f12,a12,0   //f12:1c    // f12 = pos_fの整数部分をfloatに変換
+    madd.s      f15,f14,f8  //f15:3c    // 出力値 f15 += diff * pitch
+    sub.s       f8, f11,f12 // f8:3c    // f8 = 新しいpos_fの小数部分を計算
+    addi        a13,a13,4               // 合成波形の出力先を 4 バイト進める
+    addx2       a11,a12,a11             // 元データのアドレスを pos_f の整数部分の分進める
+    madd.s      f13,f15,f9  //f13:3c    // f13 += 出力値 * gain
+    add.s       f11,f8, f10 //f11:3c    // 次回のループで使う新しい pos_f を計算 (f11 = pos_f + pitch)
+    l16si       a15,a11,0               // 次回のループで使う元データ s[0] を取得
+    l16si       a14,a11,2               // 次回のループで使う元データ s[1] を取得
+    ssi         f13,a13,0               // 合成結果の値f13を出力先にストア
+PROC_INNER1_LOOP_END:
+    s32i        a11,a2, 0
+    ssi         f8, a2, 8
+PROC_INNER1_END:
     retw
 
 #endif

--- a/src/SamplerOptimized.cpp
+++ b/src/SamplerOptimized.cpp
@@ -81,81 +81,97 @@ void SamplerOptimized::SetSample(uint8_t channel, Sample *s)
     sample = s;
 }
 
+// sampler_process_inner の動作時に必要なデータ類をまとめた構造体
+// アセンブリ言語からアクセスするのでメンバの順序を変えないこと
+struct sampler_process_inner_work_t {
+    const int16_t* src;
+    float* dst;
+    float pos_f;
+};
+
+extern "C" {
+// アセンブリ言語版を呼び出すための関数宣言
+// これをコメントアウトすると、アセンブリ言語版は呼ばれなくなり、C/C++版が呼ばれる
+    void sampler_process_inner(sampler_process_inner_work_t* result, uint32_t length, float gain, float pitch);
+}
+
+// アセンブリ言語版と同様の処理を行うC/C++版の実装
+// weak属性を付けることで、アセンブリ言語版があればそちらを使う
+__attribute((weak, optimize("-O3")))
+void sampler_process_inner(sampler_process_inner_work_t* result, uint32_t length, float gain, float pitch)
+{
+    const int16_t* s = result->src;
+    float* d = result->dst;
+    float pos_f = result->pos_f;
+    do {
+        int32_t s0 = s[0];
+        int32_t s1 = s[1];
+        // 2点間の差分にpos_fを掛けて補間
+        float val = s0 + (s1 - s0) * pos_f;
+        // 音量係数gainを掛けたあと波形合成
+        d[0] += val * gain;
+        // 出力先をひとつ進める
+        ++d;
+        // pos_fをpitchぶん進める
+        pos_f += pitch;
+        // pos_fから整数部分を取り出す
+        uint32_t intval = pos_f;
+        // pos_fから整数部分を引くことで小数部分のみを取り出す
+        pos_f -= intval;
+        // サンプリング元データ取得位置を進める
+        s += intval;
+        // 処理したのでlengthを1減らす
+    } while (--length);
+    // 結果をresultに書き戻す
+    result->src = s;
+    result->dst = d;
+    result->pos_f = pos_f;
+}
+
 __attribute((optimize("-O3")))
 void SamplerOptimized::Process(int16_t* __restrict__ output)
 {
     float data[SAMPLE_BUFFER_SIZE] = {0.0f};
 
     // 波形を生成
-    for (uint8_t i = 0; i < MAX_SOUND; i++)
+    for (uint_fast8_t i = 0; i < MAX_SOUND; i++)
     {
         SamplePlayer *player = &players[i];
         if (player->playing == false)
             continue;
-        Sample *sample = player->sample;
-        if (sample->adsrEnabled)
-            UpdateAdsr(player);
-        if (player->playing == false)
-            continue;
 
-        float pitch = PitchFromNoteNo(player->noteNo, player->sample->root);
-
-        int32_t loopEnd = sample->length;
-        int32_t loopBack = 0;
-        float gain = player->volume;
-        // adsrEnabledが有効の場合はループポイントとadsrGainを使用する。
-        if (sample->adsrEnabled) {
-            loopEnd = sample->loopEnd;
-            loopBack = sample->loopStart - loopEnd;
-            gain = player->adsrGain;
-        }
-
-        // gainにマスターボリュームを適用しておく
-        gain *= masterVolume;
-
-        // playerのメンバであるposとpos_fをローカル変数にコピーしておく。
-        auto pos = player->pos;
-        float pos_f = player->pos_f;
-        auto src = sample->sample;
-/*
-        // pitchが充分に低い場合 (0.5以下ぐらい？？) 、同一サンプル点から2回以上連続して線形補間処理ができるので、
-        // それに合わせてより軽量になりそうな処理を試す。効果がなさそうならこの分岐内の処理は省いてもよい
-        if (pitch <= 0.5f)
+        for (int j = 0; j < SAMPLE_BUFFER_SIZE / ADSR_UPDATE_SAMPLE_COUNT; j++)
         {
-            uint32_t n = 0;
-            int32_t current_sample = src[pos];
-            int32_t next_sample = src[pos + 1];
-            float diff = next_sample - current_sample;
-            do
-            {
-                // 現在の値をpos_fに応じて線形補間
-                float val = (float)current_sample + diff * pos_f;
-                // gainを掛けて波形合成
-                data[n] += val * gain;
-                pos_f += pitch;
-                if (pos_f >= 1.0f) {
-                    // pitchが1未満の条件下にあるため、pos_f+pitchは2未満であることが保証される。
-                    pos_f-=1.0f;
-                    if (++pos >= loopEnd) {
-                        pos += loopBack;
-                        if (loopBack == 0)
-                        {   // ループポイントが設定されていない場合は再生を停止する
-                            player->playing = false;
-                            break;
-                        }
-                    }
-                    current_sample = next_sample;
-                    next_sample = src[pos + 1];
-                    diff = next_sample - current_sample;
-                }
-            } while (++n < SAMPLE_BUFFER_SIZE);
-        } else
-//*/
-        { // pitchの状況に関わらず補間処理による波形生成を行う
+            Sample *sample = player->sample;
+            if (sample->adsrEnabled)
+                UpdateAdsr(player);
+            if (player->playing == false)
+                break;
+
+            float pitch = PitchFromNoteNo(player->noteNo, player->sample->root);
+
+            int32_t loopEnd = sample->length;
+            int32_t loopBack = 0;
+            float gain = player->volume;
+            // adsrEnabledが有効の場合はループポイントとadsrGainを使用する。
+            if (sample->adsrEnabled) {
+                loopEnd = sample->loopEnd;
+                loopBack = sample->loopStart - loopEnd;
+                gain = player->adsrGain;
+            }
+
+            // gainにマスターボリュームを適用しておく
+            gain *= masterVolume;
+
+            // playerのメンバであるposとpos_fをローカル変数にコピーしておく。
+            uint32_t pos = player->pos;
+            float pos_f = player->pos_f;
+            auto src = sample->sample;
 
             // ループの残り回数をremainに保持しておく
-            uint32_t remain = SAMPLE_BUFFER_SIZE;
-            auto d = data;
+            uint32_t remain = ADSR_UPDATE_SAMPLE_COUNT;
+            sampler_process_inner_work_t work = {&src[pos], &data[j * ADSR_UPDATE_SAMPLE_COUNT], pos_f};
+
             do {
                 // loopEndに到達するまでに何個サンプル出力できるか求める
                 int32_t length = 1 + ((loopEnd - pos) / pitch);
@@ -163,78 +179,68 @@ void SamplerOptimized::Process(int16_t* __restrict__ output)
                 length = remain < length ? remain : length;
                 // ループ残り回数から今回処理する分を引いておく
                 remain -= length;
-                auto s = &src[pos];
-                // 処理回数が奇数の場合は先に1つ処理しておく
-                if (length & 1) {
-                    // サンプリング元データを2点読み込む
-                    int32_t s0 = s[0];
-                    int32_t s1 = s[1];
-                    // 2点間の差分にpos_fを掛けて補間
-                    auto val = s0 + (s1 - s0) * pos_f;
-                    // 音量係数gainを掛けたあと波形合成
-                    d[0] += val * gain;
-                    // 出力先をひとつ進める
-                    ++d;
-                    // pos_fをpitchぶん進める
-                    pos_f += pitch;
-                    // pos_fから整数部分を取り出す
-                    uint32_t intval = pos_f;
-                    // pos_fから整数部分を引くことで小数部分のみを取り出す
-                    pos_f -= intval;
-                    // サンプリング元データ取得位置を進める
-                    s += intval;
-                    // 処理したのでlengthを1減らす
-                    --length;
-                }
-                // 残りの処理回数は2の倍数であるので、回数を 1/2 にしておく
-                length >>= 1;
-                if (length)
-                { // 1ループあたり2個のサンプルを処理する。(レジスタの使用効率を上げるため)
-                    do {
-                        int32_t s0 = s[0];
-                        int32_t s1 = s[1];
-                        auto val = s0 + (s1 - s0) * pos_f;
-                        d[0] += val * gain;
-                        pos_f += pitch;
-                        uint32_t intval = pos_f;
-                        pos_f -= intval;
-                        s += intval;
 
-                        s0 = s[0];
-                        s1 = s[1];
-                        val = s0 + (s1 - s0) * pos_f;
-                        d[1] += val * gain;
-                        pos_f += pitch;
-                        intval = pos_f;
-                        pos_f -= intval;
-                        s += intval;
-                        d += 2;
-                    } while (--length);
-                }
-                // posの計算は最後にループ外で行う
-                pos = s - src;
+                // 波形処理関数を呼び出す。
+                sampler_process_inner(&work, length, gain, pitch);
+
+                // 現在のサンプル位置に基づいてposがどこまで進んだか求める
+                pos = work.src - src;
                 if (pos >= loopEnd) {
                     if (loopBack == 0)
                     {   // ループポイントが設定されていない場合は再生を停止する
                         player->playing = false;
                         break;
                     }
-                    while (pos >= loopEnd) {
+                    do {
                         pos += loopBack;
-                    }
+                    } while (pos >= loopEnd);
                 }
             } while (remain != 0);
+            // ループを終えた後でposとpos_fをplayerに書き戻しておく
+            player->pos = pos;
+            player->pos_f = work.pos_f;
         }
-        // ループを終えた後でposとpos_fをplayerに書き戻しておく
-        player->pos = pos;
-        player->pos_f = pos_f;
     }
 
-    {
+    { // 生成した波形をint16_tに変換して出力先に書き込む
+#if CONFIG_IDF_TARGET_ESP32S3
+        // ESP32S3の場合はSIMD命令を使って高速化
+        __asm__ (
+        "    loop            %2, LOOP_END           \n"    // ループ開始
+        "    ee.ldf.128.ip   f11,f10,f9, f8, %1, 16 \n"    // 元データ float 4個 読み、a3 アドレスを 16 加算
+        "    ee.ldf.128.ip   f15,f14,f13,f12,%1, 16 \n"    // 元データ float 4個 読み、a3 アドレスを 16 加算
+        "    trunc.s a12, f8, 0                     \n"    //
+        "    trunc.s a13, f9, 0                     \n"    //
+        "    trunc.s a14,f10, 0                     \n"    //
+        "    trunc.s a15,f11, 0                     \n"    //
+        "    s16i    a12, %0, 0                     \n"    //
+        "    s16i    a13, %0, 2                     \n"    //
+        "    s16i    a14,%0,  4                     \n"    //
+        "    s16i    a15,%0,  6                     \n"    //
+        "    trunc.s a12,f12, 0                     \n"    //
+        "    trunc.s a13,f13, 0                     \n"    //
+        "    trunc.s a14,f14, 0                     \n"    //
+        "    trunc.s a15,f15, 0                     \n"    //
+        "    s16i    a12,%0,  8                     \n"    //
+        "    s16i    a13,%0, 10                     \n"    //
+        "    s16i    a14,%0, 12                     \n"    //
+        "    s16i    a15,%0, 14                     \n"    //
+        "    addi    %0, %0, 16                     \n"    //
+        "LOOP_END:                                  \n"    //
+        : // output-list 使用せず    // アセンブリ言語からC/C++への受渡しは無し
+        : // input-list             // C/C++からアセンブリ言語への受渡し
+            "r" ( output ),         //  %0 に変数 output の値を指定
+            "r" ( data ),           //  %1 に変数 data の値を指定
+            "r" ( SAMPLE_BUFFER_SIZE>>3 )  // %2 にバッファ長 / 8 の値を設定
+        : // clobber-list           //  値を書き換えたレジスタの申告
+            "f8","f9","f10","f11","f12","f13","f14","f15",
+            "a12","a13","a14","a15" //  書き変えたレジスタをコンパイラに知らせる
+        );
+#else
         auto o = output;
         auto d = data;
         for (int i = 0; i < SAMPLE_BUFFER_SIZE>>3; i++)
-        { // 事前にマスターボリュームを適用しているので単純に代入するのみでよい
+        { // 1ループあたりの処理回数を増やすことで処理効率を上げる
             o[0] = d[0];
             o[1] = d[1];
             o[2] = d[2];
@@ -246,5 +252,6 @@ void SamplerOptimized::Process(int16_t* __restrict__ output)
             o += 8;
             d += 8;
         }
+#endif
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,7 +125,7 @@ void setup()
     M5.Speaker.setVolume(192);
   }
   M5.Display.startWrite();
-  // M5.Display.setRotation(M5.Display.getRotation() ^ 1);
+  M5.Display.setRotation(M5.Display.getRotation() ^ 1);
   M5.Display.setTextSize(2);
   M5.Display.println("Hello World!");
   M5.Display.println("");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,7 @@ uint32_t process(SamplerBase *sampler, int16_t *output)
   __asm__ __volatile("rsr %0, ccount" : "=r"(cycle_end) ); // 処理後のCPUサイクル値を取得
   uint32_t cycle = cycle_end - cycle_begin;
 #if ENABLE_PRINTING
-  for (uint8_t i; i < SAMPLE_BUFFER_SIZE; i++)
+  for (uint_fast16_t i; i < SAMPLE_BUFFER_SIZE; i++)
   {
     Serial.printf("%d,", output[i]);
   }
@@ -40,7 +40,7 @@ uint32_t process(SamplerBase *sampler, int16_t *output)
     static int x = 0;
     static int y1 = 0;
     int dh = M5.Display.height();
-    for (int i = 0; i < SAMPLE_BUFFER_SIZE; i++)
+    for (uint_fast16_t i = 0; i < SAMPLE_BUFFER_SIZE; i++)
     {
       M5.Display.writeFastVLine(x, prev_yh[x][0], prev_yh[x][1], TFT_BLACK);
       int y0 = (dh >> 1) - (output[i] >> 7);


### PR DESCRIPTION
アセンブリ言語を使用しての高速化を行いました。
元になったC/C++の記述も条件分岐などで含まれています。

また、`SAMPLE_BUFFER_SIZE` を変更してもADSR特性が変わらないように処理を調整しました。
具体的には、 `ADSR_UPDATE_SAMPLE_COUNT` を新設し、これの値を 64 としました。

画面の向きも最初の状態と同じ 90度回転した状態に戻しておきました。