### PR TITLE
NoteOn時点でPitch計算することでProcessの負荷を軽減

### DIFF
--- a/src/SamplerOptimized.cpp
+++ b/src/SamplerOptimized.cpp
@@ -144,7 +144,7 @@ void SamplerOptimized::Process(int16_t* __restrict__ output)
         if (player->playing == false)
             continue;
 
-        for (int j = 0; j < SAMPLE_BUFFER_SIZE / ADSR_UPDATE_SAMPLE_COUNT; j++)
+        for (uint_fast8_t j = 0; j < SAMPLE_BUFFER_SIZE / ADSR_UPDATE_SAMPLE_COUNT; j++)
         {
             Sample *sample = player->sample;
             if (sample->adsrEnabled)
@@ -152,7 +152,7 @@ void SamplerOptimized::Process(int16_t* __restrict__ output)
             if (player->playing == false)
                 break;
 
-            float pitch = PitchFromNoteNo(player->noteNo, player->sample->root);
+            float pitch = player->pitch;
 
             int32_t loopEnd = sample->length;
             int32_t loopBack = 0;

--- a/src/SamplerOptimized.h
+++ b/src/SamplerOptimized.h
@@ -9,7 +9,11 @@ public:
     struct SamplePlayer
     {
         SamplePlayer(struct Sample *sample, uint8_t noteNo, float volume)
-            : sample{sample}, noteNo{noteNo}, volume{volume}, createdAt{micros()} {}
+            : sample{sample}, noteNo{noteNo}, volume{volume}, createdAt{micros()}
+            {
+                float delta = noteNo - sample->root;
+                pitch = ((pow(2.0f, delta / 12.0f)));
+            }
         SamplePlayer() : sample{nullptr}, noteNo{60}, volume{1.0f}, playing{false}, createdAt{micros()} {}
         struct Sample *sample;
         uint8_t noteNo;
@@ -21,6 +25,7 @@ public:
         bool playing = true;
         bool released = false;
         float adsrGain = 0.0f;
+        float pitch = 1.0f;
         enum SampleAdsr adsrState = SampleAdsr::attack;
     };
     void NoteOn(uint8_t noteNo, uint8_t velocity, uint8_t channel);


### PR DESCRIPTION
Process処理中に使用している `PitchFromNoteNo` がかなり重いことに気付きました。
そこでNoteOn時点でPitchを計算し、Process処理の中でのPitch計算を省くようにしてみました。
これに伴いSamplePlayerにfloat pitchメンバを追加しています。

こちらで試したCoreS3での計測結果は20msec以下となりました。



