### PR TITLE
波形合成処理の高速化

### DIFF
--- a/src/SamplerOptimized.S
+++ b/src/SamplerOptimized.S
@@ -4,6 +4,7 @@
 #include <sdkconfig.h>
 #endif
 
+/// 波形合成処理を行う関数。 ループ一回につき4サンプル分の処理を行う。
 // void sampler_process_inner(proc_inner_work_t* work, uint32_t length)
 // a2 = proc_inner_work_t* work
 // a3 = uint32_t length
@@ -12,41 +13,116 @@
     .align      4
 sampler_process_inner:
     entry       sp, 32
-    beqz        a3, PROC_INNER1_END
-    l32i        a11,a2, 0               // a11 に元データのアドレスを取得
-    l32i        a13,a2, 4               // a13 に出力先アドレスを取得
-    lsi         f8, a2, 8               // f8 に pos_f を設定
-    lsi         f9, a2, 12              // f9 に gain を設定
-    lsi         f10,a2, 16              // f10 に pitch を設定
-    addx4       a15,a3, a13             // a15 に出力先アドレスの終了アドレスを設定
+    lsi         f4, a2, 8               // f4 に pos_f を設定
+    lsi         f14,a2, 16              // f14 に pitch を設定
+    l32i        a4, a2, 4               // a4 に出力先アドレスを取得
+    add.s       f5, f4, f14             // f5 = pos_f1 = pos_f + pitch
+    add.s       f14,f14,f14             // f14 pitch = pitch * 2
+    addx4       a15,a3, a4              // a15 に出力先アドレスの終了アドレスを設定
     s32i        a15,a2, 4               // 出力先終了アドレスを結果データに先に書き戻して置く
-    addi        a13,a13,-4              // 出力先アドレスを 4 バイト戻す(ループ内の最適化の都合)
-    add.s       f11,f8, f10             // f11 = posf + pitch 新しい pos_f を計算
-    l16si       a15,a11,0               // a15 に元データ[0]を取得
-    l16si       a14,a11,2               // a14 に元データ[1]を取得
-    // ループ開始前に初回データの準備としてf11,a14,a15を準備しておく
+    srli        a3, a3, 2               // length /= 4 ループ回数を1/4にする (4サンプルずつ処理するため)
+    beqz        a3, PROC_INNER1_END     // length が 0 の場合は終了
 
-    loop        a3, PROC_INNER1_LOOP_END      // ループ開始
+// ループ開始前の時点で pos_f を4サンプル分作成しておく
+    l32i        a8, a2, 0               // a8 に元データのアドレスを取得
+    add.s       f6, f4, f14             // f6 = pos_f2 = pos_f + pitch*2
+    add.s       f7, f5, f14             // f7 = pos_f3 = pos_f1 + pitch*2
+    add.s       f14,f14,f14             // f14 元のpitchの4倍の値になる
+    utrunc.s    a13,f5,  0              // a13 = pos_f1 の整数部分を取得
+    utrunc.s    a14,f6,  0              // a14 = pos_f2 の整数部分を取得
+    utrunc.s    a15,f7,  0              // a15 = pos_f3 の整数部分を取得
+    lsi         f15,a2, 12              // f15 に gain を設定
+    addx2       a9, a13,a8              // a9 に元データの1つ先のサンプルアドレスを取得
+    addx2       a10,a14,a8              // a10 に元データの2つ先のサンプルアドレスを取得
+    addx2       a11,a15,a8              // a11 に元データの3つ先のサンプルアドレスを取得
+    ufloat.s    f9, a13, 0              // f9  = pos_f1 の整数部分をfloatに変換
+    ufloat.s    f10,a14, 0              // f10 = pos_f2 の整数部分をfloatに変換
+    ufloat.s    f11,a15, 0              // f11 = pos_f3 の整数部分をfloatに変換
+
+/// ここまでで f4, f5, f6, f7 に pos_f の値が4サンプル分が用意される。
+/// また、 a8, a9, a10, a11 に データ取得アドレス 4サンプル分が用意される。
+/// pitch は元の値の4倍にして f14 に格納しておく
+
+    loop        a3, PROC_INNER1_LOOP_END // ループ開始
+
                             //↓ここのコメントは結果が出るまでに必要なCPUサイクル数。
-                            // 例えば a12:3c は a12に結果が出るのに3サイクルかかることを示す
-    utrunc.s    a12,f11,0   //a12:3c    // a12 = f11 新しい pos_f の整数部分を取得
-    sub         a14,a14,a15             // a14 = diff = s[1] - s[0] // 元データの差分を計算
-    float.s     f15,a15,0   //f15:1c    // f15 = (float)a15 元データ[0]をfloat値に変換
-    float.s     f14,a14,0   //f14:1c    // f14 = diff = (float)a14 差分値を float に変換
-    lsi         f13,a13,4               // f13 に既存の合成波形を読出しておく (事前に-4しているので+4オフセット)
-    ufloat.s    f12,a12,0   //f12:1c    // f12 = pos_fの整数部分をfloatに変換
-    madd.s      f15,f14,f8  //f15:3c    // 出力値 f15 += diff * pitch
-    sub.s       f8, f11,f12 // f8:3c    // f8 = 新しいpos_fの小数部分を計算
-    addi        a13,a13,4               // 合成波形の出力先を 4 バイト進める
-    addx2       a11,a12,a11             // 元データのアドレスを pos_f の整数部分の分進める
-    madd.s      f13,f15,f9  //f13:3c    // f13 += 出力値 * gain
-    add.s       f11,f8, f10 //f11:3c    // 次回のループで使う新しい pos_f を計算 (f11 = pos_f + pitch)
-    l16si       a15,a11,0               // 次回のループで使う元データ s[0] を取得
-    l16si       a14,a11,2               // 次回のループで使う元データ s[1] を取得
-    ssi         f13,a13,0               // 合成結果の値f13を出力先にストア
+                            // 例えば a3:3c は a3に結果が出るのに3サイクルかかることを示す
+    l16si       a12,a8, 0               // a12 に元データ0 を取得
+    l16si       a13,a9, 0               // a13 に元データ1 を取得
+    l16si       a14,a8, 2   //f14:2c    // a14 に元データ0 の右隣の値を取得
+    l16si       a15,a9, 2   //f15:2c    // a15 に元データ1 の右側の値を取得
+    sub.s       f5, f5, f9              // f5 = pos_f1 の小数部分を計算
+    sub         a14,a14,a12             // a14 = diff0 = 元データ0 と右隣の差分を計算
+    sub         a15,a15,a13             // a15 = diff1 = 元データ1 と右隣の差分を計算
+    float.s     f8, a12,0   // f8:1c    // f8 = (float)a12 元データ0 を float に変換
+    float.s     f9, a13,0   // f9:1c    // f9 = (float)a13 元データ1 を float に変換
+    float.s     f12,a14,0   //f12:1c    // f12 = (float)a14 diff0を float に変換
+    float.s     f13,a15,0   //f13:1c    // f13 = (float)a15 diff1を float に変換
+    madd.s      f8, f12,f4  // f8:3c    // 出力値 f8 += diff0 * pos_f0
+    madd.s      f9, f13,f5  // f9:3c    // 出力値 f9 += diff1 * pos_f1
+
+    l16si       a12,a10,0               // a12 に元データ2 を取得
+    l16si       a13,a11,0               // a13 に元データ3 を取得
+    l16si       a14,a10,2               // a14 に元データ2 の右隣の値を取得
+    l16si       a15,a11,2               // a15 に元データ3 の右側の値を取得
+    sub.s       f6, f6, f10             // f6 = pos_f2 の小数部分を計算
+    sub.s       f7, f7, f11             // f7 = pos_f3 の小数部分を計算
+    sub         a14,a14,a12             // a14 = diff2 = 元データ2 と右隣の差分を計算
+    sub         a15,a15,a13             // a15 = diff3 = 元データ3 と右隣の差分を計算
+    float.s     f10,a12,0   //f10:1c    // f10 = (float)a12 元データ2 を float に変換
+    float.s     f11,a13,0   //f11:1c    // f11 = (float)a13 元データ3 を float に変換
+    float.s     f12,a14,0   //f12:1c    // f12 = (float)a14 diff2を float に変換
+    float.s     f13,a15,0   //f13:1c    // f13 = (float)a15 diff3を float に変換
+    madd.s      f10,f12,f6  //f10:3c    // 出力値 f10 += diff2 * pos_f2
+    madd.s      f11,f13,f7  //f11:3c    // 出力値 f11 += diff3 * pos_f3
+
+// ESP32S3はSIMD命令が使用可能なので分岐する
+#if CONFIG_IDF_TARGET_ESP32S3
+    ee.ldf.128.ip   f3,f2,f1,f0, a4, 0  // f0~f3 に既存の合成波形を読出しておく
+#else
+    lsi         f0, a4, 0               // f0 に既存の合成波形を読出しておく
+    lsi         f1, a4, 4               // f1 に既存の合成波形を読出しておく
+    lsi         f2, a4, 8               // f2 に既存の合成波形を読出しておく
+    lsi         f3, a4, 12              // f3 に既存の合成波形を読出しておく
+#endif
+
+    madd.s      f0, f8, f15 // f0:3c    // f0 += 出力値 * gain
+    madd.s      f1, f9, f15 // f1:3c    // f1 += 出力値 * gain
+    madd.s      f2,f10, f15 // f2:3c    // f2 += 出力値 * gain
+    madd.s      f3,f11, f15 // f3:3c    // f3 += 出力値 * gain
+    add.s       f4, f4, f14 // f4:3c    // f4 = pos_f  += pitch*4
+    add.s       f5, f5, f14 // f5:3c    // f5 = pos_f1 += pitch*4
+    add.s       f6, f6, f14 // f6:3c    // f6 = pos_f2 += pitch*4
+    add.s       f7, f7, f14 // f7:3c    // f7 = pos_f3 += pitch*4
+
+// ESP32S3はSIMD命令が使用可能なので分岐する
+#if CONFIG_IDF_TARGET_ESP32S3
+    ee.stf.128.ip f3,f2,f1,f0, a4, 16   // f0~f3 の値を出力先にストアしa4を16進める
+#else
+    ssi         f0, a4, 0               // 合成結果の値 f0 を出力先にストア
+    ssi         f1, a4, 4               // 合成結果の値 f1 を出力先にストア
+    ssi         f2, a4, 8               // 合成結果の値 f2 を出力先にストア
+    ssi         f3, a4, 12              // 合成結果の値 f3 を出力先にストア
+    addi        a4, a4, 16              // 出力先アドレスを a4 を 16 バイト進める
+#endif
+
+    utrunc.s    a12,f4,  0  //a12:3c    // a12 = pos_f の整数部分を取得
+    utrunc.s    a13,f5,  0  //a13:3c    // a13 = pos_f1 の整数部分を取得
+    utrunc.s    a14,f6,  0  //a14:3c    // a14 = pos_f2 の整数部分を取得
+    utrunc.s    a15,f7,  0  //a15:3c    // a15 = pos_f3 の整数部分を取得
+    addx2       a8, a12,a8              // a8 サンプルアドレスを進める
+    addx2       a9, a13,a9              // a9 サンプルアドレスを進める
+    addx2       a10,a14,a10             // a10 サンプルアドレスを進める
+    addx2       a11,a15,a11             // a11 サンプルアドレスを進める
+    ufloat.s    f8, a12, 0  // f8:1c    // f8  = pos_f の整数部分をfloatに変換
+    ufloat.s    f9, a13, 0  // f9:1c    // f9  = pos_f1 の整数部分をfloatに変換
+    ufloat.s    f10,a14, 0  //f10:1c    // f10 = pos_f2 の整数部分をfloatに変換
+    ufloat.s    f11,a15, 0  //f11:1c    // f11 = pos_f3 の整数部分をfloatに変換
+    sub.s       f4, f4, f8              // f4 = pos_f の小数部分を計算
+
 PROC_INNER1_LOOP_END:
-    s32i        a11,a2, 0
-    ssi         f8, a2, 8
+    s32i        a8, a2, 0
+    ssi         f4, a2, 8
 PROC_INNER1_END:
     retw
 

--- a/src/SamplerOptimized.cpp
+++ b/src/SamplerOptimized.cpp
@@ -178,7 +178,8 @@ void SamplerOptimized::Process(int16_t* __restrict__ output)
             float gain = (sample->adsrEnabled) ? player->adsrGain : player->volume;
 
             // gainにマスターボリュームを適用しておく
-            gain *= masterVolume;
+            // 後処理で float から int16_t への変換時処理を行う際の高速化の都合で、事前に 65536倍しておく
+            gain *= masterVolume * 65536;
 
             auto src = sample->sample;
             sampler_process_inner_work_t work = {&src[player->pos], &data[j * ADSR_UPDATE_SAMPLE_COUNT], player->pos_f, gain, pitch};
@@ -220,30 +221,26 @@ void SamplerOptimized::Process(int16_t* __restrict__ output)
         "   loop            %2, LOOP_END            \n"     // ループ開始
         "   ee.ldf.128.ip   f11,f10,f9, f8, %1, 16  \n"     // 元データ float 4個 読み、a3 アドレスを 16 加算
         "   ee.ldf.128.ip   f15,f14,f13,f12,%1, 16  \n"     // 元データ float 4個 読み、a3 アドレスを 16 加算
-        "   trunc.s         a12,f8, 0               \n"     // float 4個を int32_t 4個に変換
+        "   trunc.s         a12,f8, 0               \n"     // float 4個を int32_t 4個に変換する
+        "   trunc.s         a14,f10,0               \n"     // trunc.s は int32_t の範囲に収まるよう桁溢れ防止が行われる。
         "   trunc.s         a13,f9, 0               \n"     //
-        "   trunc.s         a14,f10,0               \n"     //
         "   trunc.s         a15,f11,0               \n"     //
-        "   clamps          a12,a12,15              \n"     // int32_t 4個の値が int16_t の範囲に収まるよう桁溢れを防止
-        "   clamps          a13,a13,15              \n"     //
-        "   clamps          a14,a14,15              \n"     //
-        "   clamps          a15,a15,15              \n"     //
-        "   s16i            a12,%0, 0               \n"     // 出力先に int16_t 4個書き込み
-        "   s16i            a13,%0, 2               \n"     //
+        "   srli            a12,a12,16              \n"     // 偶数indexの値について 右16bitシフトし int16_t 化する
+        "   srli            a14,a14,16              \n"     //
+        "   s32i            a13,%0, 0               \n"     // 奇数indexの値を先に 32bit のまま偶数位置へ出力する。
+        "   s32i            a15,%0, 4               \n"     // これにより右シフト処理を省略できる
+        "   s16i            a12,%0, 0               \n"     // 先ほど奇数indexの値を出力した場所に 16bit 化した偶数indexの値を出力して上書きする。
         "   s16i            a14,%0, 4               \n"     //
-        "   s16i            a15,%0, 6               \n"     //
         "   trunc.s         a12,f12,0               \n"     // float 4個を int32_t 4個に変換
-        "   trunc.s         a13,f13,0               \n"     //
         "   trunc.s         a14,f14,0               \n"     //
+        "   trunc.s         a13,f13,0               \n"     //
         "   trunc.s         a15,f15,0               \n"     //
-        "   clamps          a12,a12,15              \n"     // int32_t 4個の値が int16_t の範囲に収まるよう桁溢れを防止
-        "   clamps          a13,a13,15              \n"     //
-        "   clamps          a14,a14,15              \n"     //
-        "   clamps          a15,a15,15              \n"     //
-        "   s16i            a12,%0,  8              \n"     // 出力先に int16_t 4個書き込み
-        "   s16i            a13,%0, 10              \n"     //
+        "   srli            a12,a12,16              \n"     // 偶数indexの値について 右16bitシフトし int16_t 化する
+        "   srli            a14,a14,16              \n"     //
+        "   s32i            a13,%0, 8               \n"     // 奇数indexの値を先に 32bit のまま偶数位置へ出力する。
+        "   s32i            a15,%0, 12              \n"     // これにより右シフト処理を省略できる
+        "   s16i            a12,%0, 8               \n"     // 先ほど奇数indexの値を出力した場所に 16bit 化した偶数indexの値を出力して上書きする。
         "   s16i            a14,%0, 12              \n"     //
-        "   s16i            a15,%0, 14              \n"     //
         "   addi            %0, %0, 16              \n"     //
         "LOOP_END:                                  \n"     //
         : // output-list 使用せず    // アセンブリ言語からC/C++への受渡しは無し
@@ -260,14 +257,14 @@ void SamplerOptimized::Process(int16_t* __restrict__ output)
         auto d = data;
         for (int i = 0; i < SAMPLE_BUFFER_SIZE>>2; i++)
         { // 1ループあたりの処理回数を増やすことで処理効率を上げる
-            int32_t d0 = d[0];
             int32_t d1 = d[1];
-            int32_t d2 = d[2];
+            int32_t d0 = d[0];
             int32_t d3 = d[3];
-            o[0] = d0 > INT16_MAX ? INT16_MAX : d0 < INT16_MIN ? INT16_MIN : d0;
-            o[1] = d1 > INT16_MAX ? INT16_MAX : d1 < INT16_MIN ? INT16_MIN : d1;
-            o[2] = d2 > INT16_MAX ? INT16_MAX : d2 < INT16_MIN ? INT16_MIN : d2;
-            o[3] = d3 > INT16_MAX ? INT16_MAX : d3 < INT16_MIN ? INT16_MIN : d3;
+            int32_t d2 = d[2];
+            ((uint32_t*)o)[0] = d1;
+            o[0] = d0 >> 16;
+            ((uint32_t*)o)[1] = d3;
+            o[2] = d2 >> 16;
             o += 4;
             d += 4;
         }

--- a/src/SamplerOptimized.cpp
+++ b/src/SamplerOptimized.cpp
@@ -257,6 +257,7 @@ void SamplerOptimized::Process(int16_t* __restrict__ output)
         auto d = data;
         for (int i = 0; i < SAMPLE_BUFFER_SIZE>>2; i++)
         { // 1ループあたりの処理回数を増やすことで処理効率を上げる
+          // float から int32_t への変換。この処理は内部でtrunc.sが使用され、int32_tの範囲に収まるように桁溢れが防止される。
             int32_t d1 = d[1];
             int32_t d0 = d[0];
             int32_t d3 = d[3];


### PR DESCRIPTION
- 波形合成処理のアセンブリコードを変更、1ループ4サンプル処理するようにしました。
ESP32S3ではSIMDによるfloatの読書きを使用します。

- 合成後のfloat配列をint16_t配列に変換する処理を若干高速化しました。
float波形生成時点で65536倍しておくことで、floatからintへの変換処理 trunc.s によって桁あふれが防止されるようになります。その後、右16ビットシフトによってint16_tに変換され配列に収められます。