### PR TITLE
音を鳴らしている途中にSetTimbreするとクラッシュする問題を修正

### DIFF
--- a/include/Sampler.h
+++ b/include/Sampler.h
@@ -110,9 +110,9 @@ namespace sampler
                 samples->push_back(std::make_unique<MappedSample>(std::move(ms)));
             }
         }
-        // 指定したノートナンバーとベロシティが範囲に含まれているサンプルへの参照を返す
-        // 該当するサンプルがない場合はnulloptを返す
-        std::optional<std::reference_wrapper<const Sample>> GetAppropriateSample(uint8_t noteNo, uint8_t velocity);
+        // 指定したノートナンバーとベロシティが範囲に含まれているサンプルへのshared_ptrを返す
+        // 該当するサンプルがない場合はnullptrを返す
+        std::shared_ptr<const Sample> GetAppropriateSample(uint8_t noteNo, uint8_t velocity);
 
     private:
         // サンプルの集合
@@ -130,14 +130,14 @@ namespace sampler
         class SamplePlayer
         {
         public:
-            SamplePlayer(std::optional<std::reference_wrapper<const Sample>> sample, uint8_t noteNo, float volume, float pitchBend, uint8_t channel)
+            SamplePlayer(std::shared_ptr<const Sample> sample, uint8_t noteNo, float volume, float pitchBend, uint8_t channel)
                 : sample{std::move(sample)}, noteNo{noteNo}, volume{volume}, pitchBend{pitchBend}, channel{channel}, createdAt{sampler::micros()}
             {
                 UpdatePitch();
                 gain = volume;
             }
-            SamplePlayer() : sample{std::nullopt}, noteNo{60}, volume{1.0f}, channel{0}, createdAt{sampler::micros()}, playing{false} {}
-            std::optional<std::reference_wrapper<const Sample>> sample;
+            SamplePlayer() : sample{nullptr}, noteNo{60}, volume{1.0f}, channel{0}, createdAt{sampler::micros()}, playing{false} {}
+            std::shared_ptr<const Sample> sample;
             uint8_t noteNo;
             float volume;
             float pitchBend = 0;

--- a/src/Sampler.cpp
+++ b/src/Sampler.cpp
@@ -39,14 +39,14 @@ void Sampler::InitializeMutexes() {
 
 #include <optional>
 
-std::optional<std::reference_wrapper<const Sample>> Timbre::GetAppropriateSample(uint8_t noteNo, uint8_t velocity)
+std::shared_ptr<const Sample> Timbre::GetAppropriateSample(uint8_t noteNo, uint8_t velocity)
 {
     for (const auto& ms : *samples)
     {
         if (ms->lowerNoteNo <= noteNo && noteNo <= ms->upperNoteNo && ms->lowerVelocity <= velocity && velocity <= ms->upperVelocity)
-            return std::cref(*ms->sample);
+            return ms->sample;
     }
-    return std::nullopt;
+    return nullptr;
 }
 
 void Sampler::SetTimbre(uint8_t channel, shared_ptr<Timbre> t)
@@ -169,16 +169,16 @@ void Sampler::Channel::PitchBend(int16_t b)
 
 void Sampler::SamplePlayer::UpdatePitch()
 {
-    if (!sample.has_value()) return;
-    
-    float delta = noteNo - sample.value().get().root + pitchBend;
+    if (!sample) return;
+
+    float delta = noteNo - sample->root + pitchBend;
     pitch = ((powf(2.0f, delta / 12.0f)));
 }
 void Sampler::SamplePlayer::UpdateGain()
 {
-    if (!sample.has_value()) return;
+    if (!sample) return;
 
-    const Sample& sampleRef = sample.value().get();
+    const Sample& sampleRef = *sample;
 
     if (!sampleRef.adsrEnabled)
     {
@@ -322,8 +322,8 @@ void Sampler::Process(int16_t* __restrict__ output)
 
         for (uint_fast8_t j = 0; j < SAMPLE_BUFFER_SIZE / ADSR_UPDATE_SAMPLE_COUNT; j++)
         {
-            if (!player->sample.has_value()) break;
-            const Sample &sample = player->sample.value();
+            if (!player->sample) break;
+            const Sample &sample = *player->sample;
             if (sample.adsrEnabled)
                 player->UpdateGain();
             if (player->playing == false)

--- a/src/Sampler.cpp
+++ b/src/Sampler.cpp
@@ -55,7 +55,14 @@ void Sampler::SetTimbre(uint8_t channel, shared_ptr<Timbre> t)
 }
 void Sampler::Channel::SetTimbre(shared_ptr<Timbre> t)
 {
-    timbre = t;
+    auto samplerPtr = sampler.lock();
+    if (samplerPtr) {
+        ENTER_CRITICAL_SEMAPHORE(samplerPtr->playersMutex);
+        timbre = t;
+        EXIT_CRITICAL_SEMAPHORE(samplerPtr->playersMutex);
+    } else {
+        timbre = t;
+    }
 }
 
 void Sampler::NoteOn(uint8_t noteNo, uint8_t velocity, uint8_t channel)


### PR DESCRIPTION
## 概要

稼働中のチャンネルに対して `Sampler::SetTimbre()` で `Timbre` を差し替えると、AudioLoop 側で use-after-free が発生してクラッシュする問題を修正します。シーケンサー再生中に音色を切り替えるアプリケーション（CapsuleChord2 等）で再現していました。

## 原因

1. `SamplePlayer::sample` が `Sample` を `reference_wrapper` で保持しており、所有権が `Timbre` 側にしかなかった。`Timbre` を差し替えて旧 `Timbre` の参照カウントが 0 になると、再生中の Player が握っていた `int16_t*` バッファが解放され、`Process` 側で解放済み領域を読みに行っていた。
2. `Channel::SetTimbre` が無ロックで `shared_ptr` を代入していたため、`Channel::NoteOn` 側の `timbre` 読み取りと race していた。

## 修正内容

### 1. `SamplePlayer` がサンプルの所有権を持つ

- `Timbre::GetAppropriateSample` の戻り値を `optional<reference_wrapper<const Sample>>` から `shared_ptr<const Sample>` に変更
- `SamplePlayer::sample` メンバも `shared_ptr<const Sample>` に変更
- これにより、Timbre 差し替え後も再生中の Player が握っている Sample は Player の寿命まで生存する

### 2. `Channel::SetTimbre` を `playersMutex` 下で実行

- `Channel::NoteOn` 等と同様に `weak_ptr<Sampler>` 経由でセマフォを取得して直列化
- `shared_ptr` 代入の torn read を防止

## パフォーマンスへの影響

- オーディオ処理のホットループ（`Process` 内）では `shared_ptr` のコピーは行わず raw reference として扱うため、atomic op は発生しない
- NoteOn 1回あたり atomic op が 2回（increment/decrement）増えるのみで無視できる範囲
- 旧 Timbre のサンプルバッファは、それを使っていた Player が再生終了するまで解放が遅延する（最大 `MAX_SOUND` = 32 個分）。これは修正の本旨であり許容範囲